### PR TITLE
MariaDB won't start without defaults-extra-file as the first argument

### DIFF
--- a/mariadb/10.0/Dockerfile
+++ b/mariadb/10.0/Dockerfile
@@ -45,8 +45,8 @@ ENTRYPOINT ["/con/context/entrypoint.sh"]
 EXPOSE 3306
 
 CMD ["mysqld", \
-    "--datadir=/con/data", \
     "--defaults-extra-file=/con/configuration/my.conf", \
+    "--datadir=/con/data", \
     "--log-bin=/con/log/mariadb-bin", \
     "--log-bin-index=/con/log/mariadb-bin.index", \
     "--user=mysql"]

--- a/mariadb/10.1/Dockerfile
+++ b/mariadb/10.1/Dockerfile
@@ -45,8 +45,8 @@ ENTRYPOINT ["/con/context/entrypoint.sh"]
 EXPOSE 3306
 
 CMD ["mysqld", \
-    "--datadir=/con/data", \
     "--defaults-extra-file=/con/configuration/my.conf", \
+    "--datadir=/con/data", \
     "--log-bin=/con/log/mariadb-bin", \
     "--log-bin-index=/con/log/mariadb-bin.index", \
     "--user=mysql"]

--- a/mariadb/5.5/Dockerfile
+++ b/mariadb/5.5/Dockerfile
@@ -45,8 +45,8 @@ ENTRYPOINT ["/con/context/entrypoint.sh"]
 EXPOSE 3306
 
 CMD ["mysqld", \
-    "--datadir=/con/data", \
     "--defaults-extra-file=/con/configuration/my.conf", \
+    "--datadir=/con/data", \
     "--log-bin=/con/log/mariadb-bin", \
     "--log-bin-index=/con/log/mariadb-bin.index", \
     "--user=mysql"]


### PR DESCRIPTION
I'm in the process of building a like MariaDB instance on CentOS, and noticed that your instance won't start due to defaults-extra-file not being in the expected position in the argument list. 

Two screenshots attached... The first is the error at startup, and the second is the output from --help --verbose stating that the argument has to be passed as the first.
![startup](https://cloud.githubusercontent.com/assets/411916/5890332/35f4b814-a424-11e4-812d-f586542ae61b.png)
![argument_list](https://cloud.githubusercontent.com/assets/411916/5890333/37cea42e-a424-11e4-975e-01b4313cea15.png)

